### PR TITLE
Ajf fixes 201305

### DIFF
--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -27,6 +27,8 @@
 
 #include <config.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
 #include <string.h>
 #include <openssl/crypto.h>
 #include <openssl/objects.h>
@@ -393,6 +395,19 @@ int pkcs11_finish(ENGINE *engine)
 
 int pkcs11_init(ENGINE *engine)
 {
+	static const char *env_name = "ENGINE_PKCS11_VERBOSE";
+	const char *env_val = getenv(env_name);
+	if (env_val) {
+		char *end;
+		long tmp = strtol(env_val, &end, 10);
+		if (end != env_val && INT_MIN <= tmp && tmp <= INT_MAX)
+			verbose = (int)tmp;
+		else
+			fprintf(stderr, "%s:%s: invalid %s '%s'\n",
+				"engine_pkcs11", __func__,
+				env_name, env_val);
+	}
+
 	VERBOSE("Initializing engine");
 
 #undef CLEANUP

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -849,6 +849,8 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 		FAIL("Unable to find active slot");
 
 	tok = slot->token;
+	if (!tok)
+		FAIL("No token in active slot");
 
 	if (PKCS11_enumerate_certs(tok, &certs, &cert_count))
 		FAIL("Unable to enumerate certificates");
@@ -920,6 +922,8 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 		FAIL("Unable to find active slot");
 
 	tok = slot->token;
+	if (!tok)
+		FAIL("No token in active slot");
 
 	if (PKCS11_enumerate_certs(tok, &certs, &cert_count))
 		FAIL("Unable to enumerate certificates");

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -642,13 +642,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
 		PKCS11_release_all_slots(ctx, slot_list, slot_count);
 		return NULL;
 	}
-/* Removed for interop with some other pkcs11 libs. */
-#if 0
-	if (!tok->initialized) {
-		fprintf(stderr, "Found uninitialized token; \n");
-		return NULL;
-	}
-#endif
+
 	if (isPrivate && !tok->userPinSet && !tok->readOnly) {
 		fprintf(stderr, "Found slot without user PIN\n");
 		PKCS11_release_all_slots(ctx, slot_list, slot_count);

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -754,7 +754,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 			(key_count <= 1) ? "" : "s");
 
 	if (s_slot_key_id && *s_slot_key_id && (key_id_len != 0 || key_label)) {
-		for (n = 0; n < key_count; n++) {
+		for (n = 0; !selected_key && n < key_count; n++) {
 			PKCS11_KEY *k = keys + n;
 
 			if (verbose)
@@ -769,7 +769,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 				}
 			} else {
 				if (strcmp(k->label, key_label) == 0)
-					selected_key = k; /* FIXME: ajf -- add break here? */
+					selected_key = k;
 			}
 		}
 	} else {

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -443,18 +443,6 @@ cleanup_done:
 	return 0;
 }
 
-int pkcs11_rsa_finish(RSA *rsa)
-{
-	zero_pin();
-	if (module) {
-		free(module);
-		module = NULL;
-	}
-	/* need to free RSA_ex_data? */
-	/* FIXME: ajf -- need to PKCS11_CTX_free(ctx)? */
-	return 1;
-}
-
 static int hex_to_bin(const char *in, unsigned char *out, size_t *outlen)
 {
 	size_t left, count = 0;

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -281,6 +281,7 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 				unsigned char *id, size_t *id_len,
 				char **label)
 {
+	size_t slot_id_len;
 	int n, i;
 
 	if (!slot_id)
@@ -293,10 +294,12 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 #define HEXDIGITS "01234567890ABCDEFabcdef"
 #define DIGITS "0123456789"
 
+	slot_id_len = strlen(slot_id);
+
 	/* first: pure hex number (id, slot is 0) */
-	if (strspn(slot_id, HEXDIGITS) == strlen(slot_id)) {
+	if (strspn(slot_id, HEXDIGITS) == slot_id_len) {
 		/* ah, easiest case: only hex. */
-		if ((strlen(slot_id) + 1) / 2 > *id_len)
+		if ((slot_id_len + 1) / 2 > *id_len)
 			FAIL("Id string too long!");
 		*slot = 0;
 		return hex_to_bin(slot_id, id, id_len);
@@ -316,11 +319,11 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 			return 1;
 		}
 
-		if (strspn(slot_id + i, HEXDIGITS) + i != strlen(slot_id))
+		if (strspn(slot_id + i, HEXDIGITS) + i != slot_id_len)
 			FAIL("Non-hex Id after slot number");
 
 		/* ah, rest is hex */
-		if ((strlen(slot_id) - i + 1) / 2 > *id_len)
+		if ((slot_id_len - i + 1) / 2 > *id_len)
 			FAIL1("Id string too long (max=%d)", (int)*id_len);
 
 		*slot = n;
@@ -329,11 +332,11 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 
 	/* third: id_<id>  */
 	if (strncmp(slot_id, "id_", 3) == 0) {
-		if (strspn(slot_id + 3, HEXDIGITS) + 3 != strlen(slot_id))
+		if (strspn(slot_id + 3, HEXDIGITS) + 3 != slot_id_len)
 			FAIL("Non-hex Id after 'id_'");
 
 		/* ah, rest is hex */
-		if ((strlen(slot_id) - 3 + 1) / 2 > *id_len)
+		if ((slot_id_len - 3 + 1) / 2 > *id_len)
 			FAIL1("Id string too long (max=%d)", (int)*id_len);
 
 		*slot = 0;
@@ -372,11 +375,11 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 	/* now followed by "id_" */
 	if (strncmp(slot_id + i, "id_", 3) == 0) {
 		if (strspn(slot_id + i + 3, HEXDIGITS) + 3 + i !=
-		    strlen(slot_id))
+		    slot_id_len)
 			FAIL("Non-hex data after 'id_' after 'slot_'");
 
 		/* ah, rest is hex */
-		if ((strlen(slot_id) - i - 3 + 1) / 2 > *id_len)
+		if ((slot_id_len - i - 3 + 1) / 2 > *id_len)
 			FAIL1("Id string too long (max=%d)", (int)*id_len);
 
 		*slot = n;

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -507,10 +507,9 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 	if (!tok)
 		FAIL("Found empty token");
 
-	if (verbose) {
-		fprintf(stderr, "Found slot:  %s\n", slot->description);
-		fprintf(stderr, "Found token: %s\n", slot->token->label);
-	}
+	if (verbose)
+		fprintf(stderr, "Found slot '%s', token '%s'\n",
+			slot->description, slot->token->label);
 
 	if (PKCS11_enumerate_certs(tok, &certs, &cert_count))
 		FAIL("Unable to enumerate certificates");
@@ -672,10 +671,9 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 	if (isPrivate && !tok->userPinSet && !tok->readOnly)
 		FAIL("Found slot without user PIN");
 
-	if (verbose) {
-		fprintf(stderr, "Found slot:  %s\n", slot->description);
-		fprintf(stderr, "Found token: %s\n", slot->token->label);
-	}
+	if (verbose)
+		fprintf(stderr, "Found slot '%s', token '%s'\n",
+			slot->description, slot->token->label);
 
 	if (PKCS11_enumerate_certs(tok, &certs, &cert_count))
 		FAIL("Unable to enumerate certificates");

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -761,10 +761,10 @@ cleanup_done:
 
 PKCS11_CERT *scan_certs(PKCS11_CERT *certs,
 			unsigned int cert_count,
-			char * id,
+			char *id,
 			unsigned int id_len)
 {
-	PKCS11_CERT * rv = NULL;
+	PKCS11_CERT *rv = NULL;
 	unsigned int n;
 	unsigned int cert_num = 0;
 

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -40,14 +40,14 @@
 #endif
 
 /** The maximum length of an internally-allocated PIN */
-#define MAX_PIN_LENGTH   32
+#define MAX_PIN_LENGTH 32
 
 static PKCS11_CTX *ctx;
 
-/** 
+/**
  * The PIN used for login. Cache for the get_pin function.
  * The memory for this PIN is always owned internally,
- * and may be freed as necessary. Before freeing, the PIN 
+ * and may be freed as necessary. Before freeing, the PIN
  * must be whitened, to prevent security holes.
  */
 static char *pin = NULL;
@@ -115,7 +115,7 @@ int inc_verbose(void)
 /* either get the pin code from the supplied callback data, or get the pin
  * via asking our self. In both cases keep a copy of the pin code in the
  * pin variable (strdup'ed copy). */
-static int get_pin(UI_METHOD * ui_method, void *callback_data)
+static int get_pin(UI_METHOD *ui_method, void *callback_data)
 {
 	int rv = 0;
 	UI *ui;
@@ -157,7 +157,7 @@ static int get_pin(UI_METHOD * ui_method, void *callback_data)
 	if (UI_process(ui)) {
 		FAIL("UI_process failed");
 	}
-	
+
 	rv = 1; /* success! */
 
 cleanup_release_ui:
@@ -173,7 +173,7 @@ int set_init_args(const char *init_args_orig)
 	return 1;
 }
 
-int pkcs11_finish(ENGINE * engine)
+int pkcs11_finish(ENGINE *engine)
 {
 	if (ctx) {
 		PKCS11_CTX_unload(ctx);
@@ -184,7 +184,7 @@ int pkcs11_finish(ENGINE * engine)
 	return 1;
 }
 
-int pkcs11_init(ENGINE * engine)
+int pkcs11_init(ENGINE *engine)
 {
 	if (verbose) {
 		fprintf(stderr, "initializing engine\n");
@@ -200,7 +200,7 @@ int pkcs11_init(ENGINE * engine)
 #undef CLEANUP
 #define CLEANUP cleanup_release_ctx
 
-        PKCS11_CTX_init_args(ctx, init_args);
+	PKCS11_CTX_init_args(ctx, init_args);
 	if (PKCS11_CTX_load(ctx, module) < 0) {
 		FAIL1("Unable to load module '%s'", module);
 	}
@@ -215,7 +215,7 @@ cleanup_done:
 	return 0;
 }
 
-int pkcs11_rsa_finish(RSA * rsa)
+int pkcs11_rsa_finish(RSA *rsa)
 {
 	zero_pin();
 	if (module) {
@@ -227,7 +227,7 @@ int pkcs11_rsa_finish(RSA * rsa)
 	return 1;
 }
 
-static int hex_to_bin(const char *in, unsigned char *out, size_t * outlen)
+static int hex_to_bin(const char *in, unsigned char *out, size_t *outlen)
 {
 	size_t left, count = 0;
 
@@ -279,7 +279,7 @@ cleanup_zero_outlen:
 /* parse string containing slot and id information */
 
 static int parse_slot_id_string(const char *slot_id, int *slot,
-				unsigned char *id, size_t * id_len,
+				unsigned char *id, size_t *id_len,
 				char **label)
 {
 	int n, i;
@@ -363,7 +363,7 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 	if (slot_id[i + 5] == 0) {
 		*slot = n;
 		*id_len = 0;
-		return 1; 
+		return 1;
 	}
 
 	if (slot_id[i + 5] != '-') {
@@ -389,7 +389,7 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 	/* ... or "label_" */
 	if (strncmp(slot_id + i, "label_", 6) == 0) {
 		*slot = n;
-                *label = strdup(slot_id + i + 6);
+		*label = strdup(slot_id + i + 6);
 		return !!*label;
 	}
 
@@ -404,7 +404,7 @@ cleanup_done:
 /* prototype for OpenSSL ENGINE_load_cert */
 /* used by load_cert_ctrl via ENGINE_ctrl for now */
 
-static X509 *pkcs11_load_cert(ENGINE * e, const char *s_slot_cert_id)
+static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 {
 	PKCS11_SLOT *slot_list, *slot;
 	PKCS11_SLOT *found_slot = NULL;
@@ -478,7 +478,7 @@ static X509 *pkcs11_load_cert(ENGINE * e, const char *s_slot_cert_id)
 		}
 
 		if (slot_nr != -1 &&
-			slot_nr == PKCS11_get_slotid_from_slot(slot)) {
+		    slot_nr == PKCS11_get_slotid_from_slot(slot)) {
 			found_slot = slot;
 		}
 
@@ -499,7 +499,7 @@ static X509 *pkcs11_load_cert(ENGINE * e, const char *s_slot_cert_id)
 		if (!(slot = PKCS11_find_token(ctx, slot_list, slot_count)))
 			FAIL("Didn't find any tokens");
 	} else if (found_slot) {
-		slot = found_slot; 
+		slot = found_slot;
 	} else {
 		FAIL1("Invalid slot number: %d", slot_nr);
 	}
@@ -551,7 +551,7 @@ cleanup_done:
 	return x509;
 }
 
-int load_cert_ctrl(ENGINE * e, void *p)
+int load_cert_ctrl(ENGINE *e, void *p)
 {
 	struct {
 		const char *s_slot_cert_id;
@@ -565,8 +565,8 @@ int load_cert_ctrl(ENGINE * e, void *p)
 	return !!parms->cert;
 }
 
-static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
-				 UI_METHOD * ui_method, void *callback_data,
+static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
+				 UI_METHOD *ui_method, void *callback_data,
 				 int isPrivate)
 {
 	PKCS11_SLOT *slot_list, *slot;
@@ -642,7 +642,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
 		}
 
 		if (slot_nr != -1 &&
-			slot_nr == PKCS11_get_slotid_from_slot(slot)) {
+		    slot_nr == PKCS11_get_slotid_from_slot(slot)) {
 			found_slot = slot;
 		}
 
@@ -711,7 +711,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
 		   then use a NULL pin. Otherwise, check if a PIN exists. If
 		   not, allocate and obtain a new PIN. */
 		if (tok->secureLogin) {
-			/* Free the PIN if it has already been 
+			/* Free the PIN if it has already been
 			   assigned (i.e, cached by get_pin) */
 			zero_pin();
 		} else if (!pin) {
@@ -720,7 +720,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
 				FAIL("Could not allocate memory for PIN");
 			}
 			pin_length = MAX_PIN_LENGTH;
-			if (!get_pin(ui_method, callback_data) ) {
+			if (!get_pin(ui_method, callback_data)) {
 				zero_pin();
 				FAIL("No PIN was entered");
 			}
@@ -732,11 +732,11 @@ static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
 			zero_pin();
 			FAIL("Login failed");
 		}
-		/* Login successful, PIN retained in case further logins are 
+		/* Login successful, PIN retained in case further logins are
 		   required. This will occur on subsequent calls to the
 		   pkcs11_load_key function. Subsequent login calls should be
 		   relatively fast (the token should maintain its own login
-		   state), although there may still be a slight performance 
+		   state), although there may still be a slight performance
 		   penalty. We could maintain state noting that successful
 		   login has been performed, but this state may not be updated
 		   if the token is removed and reinserted between calls. It
@@ -792,7 +792,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
 	if (isPrivate) {
 		pk = PKCS11_get_private_key(selected_key);
 	} else {
-		/*pk = PKCS11_get_public_key(&keys[0]);
+		/* pk = PKCS11_get_public_key(&keys[0]);
 		   need a get_public_key? */
 		pk = PKCS11_get_private_key(selected_key);
 	}
@@ -812,8 +812,8 @@ cleanup_release_slots:
 #undef CLEANUP
 #define CLEANUP cleanup_done
 
-EVP_PKEY *pkcs11_load_public_key(ENGINE * e, const char *s_key_id,
-				 UI_METHOD * ui_method, void *callback_data)
+EVP_PKEY *pkcs11_load_public_key(ENGINE *e, const char *s_key_id,
+				 UI_METHOD *ui_method, void *callback_data)
 {
 	EVP_PKEY *pk = NULL;
 
@@ -825,8 +825,8 @@ cleanup_done:
 	return pk;
 }
 
-EVP_PKEY *pkcs11_load_private_key(ENGINE * e, const char *s_key_id,
-				  UI_METHOD * ui_method, void *callback_data)
+EVP_PKEY *pkcs11_load_private_key(ENGINE *e, const char *s_key_id,
+				  UI_METHOD *ui_method, void *callback_data)
 {
 	EVP_PKEY *pk;
 

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -470,7 +470,8 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 			strcpy(flags, "no token");
 		}
 
-		if ((m = strlen(flags)) != 0)
+		m = strlen(flags);
+		if (m)
 			flags[m - 2] = '\0';
 
 		if (slot_nr != -1 &&
@@ -492,7 +493,8 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 	}
 
 	if (slot_nr == -1) {
-		if (!(slot = PKCS11_find_token(ctx, slot_list, slot_count)))
+		slot = PKCS11_find_token(ctx, slot_list, slot_count);
+		if (!slot)
 			FAIL("Didn't find any tokens");
 	} else if (found_slot) {
 		slot = found_slot;
@@ -631,7 +633,8 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 			strcpy(flags, "no token");
 		}
 
-		if ((m = strlen(flags)) != 0)
+		m = strlen(flags);
+		if (m)
 			flags[m - 2] = '\0';
 
 		if (slot_nr != -1 &&
@@ -652,7 +655,8 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 	}
 
 	if (slot_nr == -1) {
-		if (!(slot = PKCS11_find_token(ctx, slot_list, slot_count)))
+		slot = PKCS11_find_token(ctx, slot_list, slot_count);
+		if (!slot)
 			FAIL("Didn't find any tokens");
 	} else if (found_slot) {
 		slot = found_slot;

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -824,7 +824,7 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 	PKCS11_TOKEN *token;
 	PKCS11_CERT *certs, *selected_cert = NULL;
 	X509 *x509 = NULL;
-	unsigned int slot_count, cert_count, n;
+	unsigned int slot_count, cert_count;
 	unsigned char cert_id[MAX_VALUE_LEN / 2];
 	size_t cert_id_len = sizeof(cert_id);
 	char *cert_label = NULL;
@@ -897,7 +897,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 	PKCS11_KEY *keys, *selected_key = NULL;
 	PKCS11_CERT *certs;
 	EVP_PKEY *pk = NULL;
-	unsigned int slot_count, cert_count, key_count, n;
+	unsigned int slot_count, cert_count, key_count;
 	unsigned char key_id[MAX_VALUE_LEN / 2];
 	size_t key_id_len = sizeof(key_id);
 	char *key_label = NULL;
@@ -986,6 +986,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 	VERBOSE2("Found %u key%s:", key_count, PLURAL_OF(key_count));
 
 	if (s_slot_key_id && *s_slot_key_id && (key_id_len != 0 || key_label)) {
+		unsigned int n;
 		for (n = 0; n < key_count; n++) {
 			PKCS11_KEY *k = keys + n;
 

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -821,7 +821,7 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 {
 	PKCS11_SLOT *slot_list;
 	PKCS11_SLOT *slot = NULL;
-	PKCS11_TOKEN *tok;
+	PKCS11_TOKEN *token;
 	PKCS11_CERT *certs, *selected_cert = NULL;
 	X509 *x509 = NULL;
 	unsigned int slot_count, cert_count, n;
@@ -848,11 +848,11 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 	if (!slot)
 		FAIL("Unable to find active slot");
 
-	tok = slot->token;
-	if (!tok)
+	token = slot->token;
+	if (!token)
 		FAIL("No token in active slot");
 
-	if (PKCS11_enumerate_certs(tok, &certs, &cert_count))
+	if (PKCS11_enumerate_certs(token, &certs, &cert_count))
 		FAIL("Unable to enumerate certificates");
 
 	selected_cert = scan_certs(certs, cert_count,
@@ -893,7 +893,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 {
 	PKCS11_SLOT *slot_list;
 	PKCS11_SLOT *slot = NULL;
-	PKCS11_TOKEN *tok;
+	PKCS11_TOKEN *token;
 	PKCS11_KEY *keys, *selected_key = NULL;
 	PKCS11_CERT *certs;
 	EVP_PKEY *pk = NULL;
@@ -921,24 +921,24 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 	if (!slot)
 		FAIL("Unable to find active slot");
 
-	tok = slot->token;
-	if (!tok)
+	token = slot->token;
+	if (!token)
 		FAIL("No token in active slot");
 
-	if (PKCS11_enumerate_certs(tok, &certs, &cert_count))
+	if (PKCS11_enumerate_certs(token, &certs, &cert_count))
 		FAIL("Unable to enumerate certificates");
 
-	if (isPrivate && !tok->userPinSet && !tok->readOnly)
+	if (isPrivate && !token->userPinSet && !token->readOnly)
 		FAIL("Found slot without user PIN");
 
 	scan_certs(certs, cert_count, key_id, key_id_len);
 
 	/* Perform login to the token if required */
-	if (tok->loginRequired) {
+	if (token->loginRequired) {
 		/* If the token has a secure login (i.e., an external keypad),
 		   then use a NULL pin. Otherwise, check if a PIN exists. If
 		   not, allocate and obtain a new PIN. */
-		if (tok->secureLogin) {
+		if (token->secureLogin) {
 			/* Free the PIN if it has already been
 			   assigned (i.e, cached by get_pin) */
 			zero_pin();
@@ -977,7 +977,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 	}
 
 	/* Make sure there is at least one private key on the token */
-	if (PKCS11_enumerate_keys(tok, &keys, &key_count))
+	if (PKCS11_enumerate_keys(token, &keys, &key_count))
 		FAIL("Unable to enumerate keys");
 
 	if (key_count == 0)

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -39,6 +39,15 @@
 #define strncasecmp strnicmp
 #endif
 
+static const char * SLOT_ID_USAGE =
+	"unable to parse slot cert expression '%s'\n"
+	"supported formats: <id>, <slot>:<id>, id_<id>,"
+	" slot_<slot>-id_<id>, label_<label>,"
+	" slot_<slot>-label_<label>\n"
+	"where <slot> is the slot number as normal integer,\n"
+	"and <id> is the id number as hex string,\n"
+	"and <label> is the textual key label string.\n";
+
 /** The maximum length of an internally-allocated PIN */
 #define MAX_PIN_LENGTH 32
 
@@ -424,17 +433,10 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 	if (s_slot_cert_id && *s_slot_cert_id) {
 		n = parse_slot_id_string(s_slot_cert_id, &slot_nr,
 					 cert_id, &cert_id_len, &cert_label);
-		if (!n) {
-			fprintf(stderr,
-				"supported formats: <id>, <slot>:<id>, id_<id>, slot_<slot>-id_<id>, label_<label>, slot_<slot>-label_<label>\n");
-			fprintf(stderr,
-				"where <slot> is the slot number as normal integer,\n");
-			fprintf(stderr,
-				"and <id> is the id number as hex string.\n");
-			fprintf(stderr,
-				"and <label> is the textual key label string.\n");
-			FAIL("Could not parse slot_id specification");
-		}
+		if (!n)
+			FAIL2("error parsing '%s':\n%s",
+			      s_slot_cert_id, SLOT_ID_USAGE);
+
 		if (verbose) {
 			fprintf(stderr, "Looking in slot %d for certificate: ",
 				slot_nr);
@@ -587,17 +589,10 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 		n = parse_slot_id_string(s_slot_key_id, &slot_nr,
 					 key_id, &key_id_len, &key_label);
 
-		if (!n) {
-			fprintf(stderr,
-				"supported formats: <id>, <slot>:<id>, id_<id>, slot_<slot>-id_<id>, label_<label>, slot_<slot>-label_<label>\n");
-			fprintf(stderr,
-				"where <slot> is the slot number as normal integer,\n");
-			fprintf(stderr,
-				"and <id> is the id number as hex string.\n");
-			fprintf(stderr,
-				"and <label> is the textual key label string.\n");
-			FAIL("Could not parse slot_id specification");
-		}
+		if (!n)
+			FAIL2("error parsing '%s':\n%s",
+			      s_slot_key_id, SLOT_ID_USAGE);
+
 		if (verbose) {
 			fprintf(stderr, "Looking in slot %d for key: ",
 				slot_nr);

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -888,7 +888,7 @@ int load_cert_ctrl(ENGINE *e, void *p)
 
 static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *slot_id,
 				 UI_METHOD *ui_method, void *callback_data,
-				 int isPrivate)
+				 int is_private)
 {
 	PKCS11_SLOT *slots;
 	PKCS11_SLOT *slot = NULL;
@@ -927,7 +927,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *slot_id,
 	if (PKCS11_enumerate_certs(token, &certs, &cert_count))
 		FAIL("Unable to enumerate certificates");
 
-	if (isPrivate && !token->userPinSet && !token->readOnly)
+	if (is_private && !token->userPinSet && !token->readOnly)
 		FAIL("Found slot without user PIN");
 
 	scan_certs(certs, cert_count, key_id, key_id_len);
@@ -1024,7 +1024,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *slot_id,
 	if (!key)
 		FAIL("Key not found");
 
-	if (isPrivate) {
+	if (is_private) {
 		pk = PKCS11_get_private_key(key);
 	} else {
 		/* pk = PKCS11_get_public_key(&keys[0]);

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -408,8 +408,17 @@ static int parse_slot_id_string_aux(const char *slot_id,
 				    char **label,
 				    const char *use)
 {
-	int rc = parse_slot_id_string(slot_id, slot_nr,
-				      id, id_len, label);
+	int rc = 1;
+
+	/* Empty / blank slot+id specifier is allowed. */
+	if (!slot_id || slot_id[0] == '\0') {
+		id[0] = '\0';
+		*id_len = 0;
+		return 1;
+	}
+
+	rc = parse_slot_id_string(slot_id, slot_nr,
+				  id, id_len, label);
 
 #undef CLEANUP
 #define CLEANUP cleanup_done
@@ -543,8 +552,7 @@ static X509 *pkcs11_load_cert(ENGINE *e, const char *s_slot_cert_id)
 #undef CLEANUP
 #define CLEANUP cleanup_done
 
-	if (s_slot_cert_id && *s_slot_cert_id &&
-	    !parse_slot_id_string_aux(s_slot_cert_id, &slot_nr,
+	if (!parse_slot_id_string_aux(s_slot_cert_id, &slot_nr,
 				      cert_id, &cert_id_len, &cert_label,
 				      "certificate"))
 		return NULL;
@@ -629,8 +637,7 @@ static EVP_PKEY *pkcs11_load_key(ENGINE *e, const char *s_slot_key_id,
 #undef CLEANUP
 #define CLEANUP cleanup_done
 
-	if (s_slot_key_id && *s_slot_key_id &&
-	    !parse_slot_id_string_aux(s_slot_key_id, &slot_nr,
+	if (!parse_slot_id_string_aux(s_slot_key_id, &slot_nr,
 				      key_id, &key_id_len, &key_label,
 				      "key"))
 		return NULL;

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -124,11 +124,9 @@ struct pkcs11_key_ext {
 
 };
 
-/* This is structured as storage, index to one-past-end of used, and
- * index to one-past-end of allocated. */
-struct pkcs11_key_ext *key_exts;
-int key_ext_count;
-int key_ext_alloc;
+static struct pkcs11_key_ext *key_exts; /* actual storage */
+static int key_ext_count;		/* index to one-past-end of used */
+static int key_ext_alloc;		/* index to one-past-end of alloc */
 
 /* Allocate initial storage for extra data for keys. */
 static int initialize_key_ext_info()
@@ -617,10 +615,10 @@ cleanup_done:
 	return rv;
 }
 
-PKCS11_CERT *scan_certs(PKCS11_CERT *certs,
-			unsigned int cert_count,
-			char *id,
-			unsigned int id_len)
+static PKCS11_CERT *scan_certs(PKCS11_CERT *certs,
+			       unsigned int cert_count,
+			       char *id,
+			       unsigned int id_len)
 {
 	PKCS11_CERT *rv = NULL;
 	unsigned int n;

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -411,7 +411,6 @@ static PKCS11_SLOT *scan_slots(const unsigned int slot_count,
 
 	for (n = 0; n < slot_count; n++) {
 		char flags[64];
-		int m;
 		PKCS11_SLOT *slot = slot_list + n;
 		unsigned long slotid = PKCS11_get_slotid_from_slot(slot);
 		if (slot_nr != -1 && slot_nr == slotid)
@@ -426,21 +425,22 @@ static PKCS11_SLOT *scan_slots(const unsigned int slot_count,
 
 		flags[0] = '\0';
 		if (!slot->token) {
-			strcpy(flags, "no token, ");
+			strcpy(flags, "no token");
 		} else if (!slot->token->initialized) {
-			strcat(flags, "uninitialized, ");
+			strcat(flags, "uninitialized");
 		} else {
+			int m;
 			if (!slot->token->userPinSet)
 				strcat(flags, "no pin, ");
 			if (slot->token->loginRequired)
 				strcat(flags, "login, ");
 			if (slot->token->readOnly)
 				strcat(flags, "ro, ");
+			m = strlen(flags);
+			if (m)
+				flags[m - 2] = '\0';
 		}
 
-		m = strlen(flags);
-		if (m)
-			flags[m - 2] = '\0';
 
 		fprintf(stderr, "[%lu] %-25.25s  %-16s",
 			slotid, slot->description, flags);

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -349,7 +349,8 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 	/* last try: it has to be slot_<slot> and then "-id_<cert>" */
 
 	if (strncmp(slot_id, "slot_", 5) != 0)
-		FAIL("Format does not start with 'slot_', which was last option");
+		FAIL1("Unrecognized format '%s' (expected 'slot_...')",
+		      slot_id);
 
 	/* slot is an decimal int. */
 	if (sscanf(slot_id + 5, "%d", &n) != 1)

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -50,8 +50,8 @@ static PKCS11_CTX *ctx;
  * and may be freed as necessary. Before freeing, the PIN
  * must be whitened, to prevent security holes.
  */
-static char *pin = NULL;
-static int pin_length = 0;
+static char *pin;
+static int pin_length;
 
 /* Convenience function for wiping and freeing the stored PIN. */
 static void zero_pin()
@@ -64,11 +64,11 @@ static void zero_pin()
 	}
 }
 
-static int verbose = 0;
+static int verbose;
 
-static char *module = NULL;
+static char *module;
 
-static char *init_args = NULL;
+static char *init_args;
 
 int set_module(const char *modulename)
 {

--- a/src/engine_pkcs11.h
+++ b/src/engine_pkcs11.h
@@ -47,8 +47,6 @@ int pkcs11_finish(ENGINE * engine);
 
 int pkcs11_init(ENGINE * engine);
 
-int pkcs11_rsa_finish(RSA * rsa);
-
 EVP_PKEY *pkcs11_load_public_key(ENGINE * e, const char *s_key_id,
 				 UI_METHOD * ui_method, void *callback_data);
 

--- a/src/engine_pkcs11.h
+++ b/src/engine_pkcs11.h
@@ -55,4 +55,6 @@ EVP_PKEY *pkcs11_load_public_key(ENGINE * e, const char *s_key_id,
 EVP_PKEY *pkcs11_load_private_key(ENGINE * e, const char *s_key_id,
 				  UI_METHOD * ui_method, void *callback_data);
 
+int release_key(EVP_PKEY *p);
+
 #endif

--- a/src/engine_pkcs11.h
+++ b/src/engine_pkcs11.h
@@ -33,26 +33,126 @@
 #include <openssl/objects.h>
 #include <openssl/engine.h>
 
+/**
+ * Specify the pkcs11 provider, e.g., opensc-pkcs11.so.
+ *
+ * @param modulename the path to the pkcs11 provider shared library
+ *
+ * @return 1 in all cases.
+ */
 int set_module(const char *modulename);
 
+/**
+ * Set the PIN used for login. A copy of the PIN shall be made.
+ *
+ * If the PIN cannot be assigned, the value 0 shall be returned
+ * and errno shall be set as follows:
+ *
+ *   EINVAL - a NULL PIN was supplied
+ *   ENOMEM - insufficient memory to copy the PIN
+ *
+ * @param pin the pin to use for login. Must not be NULL.
+ *
+ * @return 1 on success, 0 on failure.
+ */
 int set_pin(const char *pin);
 
-int set_init_args(const char *init_args_orig);
+/**
+ * Provide the arguments for PKCS11_CTX_init_args.
+ *
+ * @param args arguments to be given when creating a new PKCS11 context.
+ *
+ * @return 1 in all cases.
+ */
+int set_init_args(const char *args);
 
-int load_cert_ctrl(ENGINE * e, void *p);
+/**
+ * Initialize the given engine.
+ *
+ * Among other actions, this function checks the environment variable
+ * "ENGINE_PKCS11_VERBOSE"; if it is a non-zero integer, the verbose
+ * output will be enabled.
+ *
+ * @param engine the engine to be initialized.
+ *
+ * @return 1 if engine was successfully initialized, 0 otherwise.
+ */
+int pkcs11_init(ENGINE *engine);
 
+/**
+ * Shut down the given engine.
+ *
+ * @param engine the engine to be wound down.
+ *
+ * @return 1 in all cases.
+ */
+int pkcs11_finish(ENGINE *engine);
+
+/**
+ * Load a particular certificate from the token.
+ *
+ * The parameter is a pointer to a structure which contains the
+ * slot_id (describing where to find the certificate), and a X509*
+ * (which is where the certificate is copied, if it is found.)
+ *
+ *     struct {
+ *         const char *slot_id;
+ *         X509 *cert;
+ *     };
+ *
+ * @param p pointer to a structure as given above.
+ *
+ * @return zero if no cert found, non-zero if cert found.
+ */
+int load_cert_ctrl(ENGINE *e, void *p);
+
+/**
+ * Release a key and all resources associated with that key.
+ *
+ * @param pkey pointer to the evp_pkey to be freed.
+ *
+ * @return 1 in all cases.
+ */
+int release_key(EVP_PKEY *pkey);
+
+/**
+ * Increase verbosity.
+ *
+ * If this is greater than 0, then the engine emits diagnostics to
+ * stderr.
+ *
+ * As of 2013-05, there are no shades of grey; the only values that
+ * matter are zero and "not zero".
+ *
+ * @return 1 in all cases.
+ */
 int inc_verbose(void);
 
-int pkcs11_finish(ENGINE * engine);
+/**
+ * Attempt to load a public key at the given @slot_id.
+ *
+ * @return NULL on failure, live key on success. 
+ */
+EVP_PKEY *pkcs11_load_public_key(ENGINE *e, const char *slot_id,
+				 UI_METHOD *ui_method, void *callback_data);
 
-int pkcs11_init(ENGINE * engine);
-
-EVP_PKEY *pkcs11_load_public_key(ENGINE * e, const char *s_key_id,
-				 UI_METHOD * ui_method, void *callback_data);
-
-EVP_PKEY *pkcs11_load_private_key(ENGINE * e, const char *s_key_id,
-				  UI_METHOD * ui_method, void *callback_data);
-
-int release_key(EVP_PKEY *p);
+/**
+ * Attempt to load a private key at the given @slot_id.
+ *
+ * NOTE: the engine has to allocate extra resources to make sure that
+ * the private key works even after leaving the engine.  The default
+ * EVP_PKEY_free method does not know about these extra resources, so
+ * do not use that method on this key.
+ *
+ * Instead, to insure that these resources are properly released,
+ * please use the RELEASE_KEY control:
+ *
+ *     ENGINE_ctrl_cmd( engine, "RELEASE_KEY", 0,
+ *                    (void *)pkey, NULL, 0 );
+ *
+ * @return NULL on failure, live key on success. 
+ */
+EVP_PKEY *pkcs11_load_private_key(ENGINE *e, const char *slot_id,
+				  UI_METHOD *ui_method, void *callback_data);
 
 #endif

--- a/src/fail.h
+++ b/src/fail.h
@@ -56,4 +56,12 @@
 		goto CLEANUP;						\
 	} while (0)
 
+/** Exit with an error message and two arguments. */
+#define FAIL2(msg, arg1, arg2)						\
+	do {								\
+		fprintf(stderr, "%s: " msg "\n",			\
+			__func__ , arg1, arg2);				\
+		goto CLEANUP;						\
+	} while (0)
+
 #endif /* ENGINE_PKCS11_SRC_FAIL_H */

--- a/src/fail.h
+++ b/src/fail.h
@@ -1,0 +1,59 @@
+#ifndef ENGINE_PKCS11_SRC_FAIL_H
+#define ENGINE_PKCS11_SRC_FAIL_H 1
+
+/*
+ * Copyright (c) 2013 Anthony Foiani <anthony.foiani@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file fail.h
+ *
+ * Convenience functions for quitting tersely yet gracefully.
+ *
+ * The "fail" macro in engine_pkcs11.c attempts to make the core code
+ * easier to read.  Inspired by this, we provide variants that
+ * continue to improve readability while improving correctness.
+ *
+ * We further leverage the Linux coding style of using goto+label to
+ * perform different stages of cleanups, as well as providing a
+ * C++-ish means of providing primitive unwind capability.
+ */
+
+/** The current output destination label. */
+#define CLEANUP cleanup_done
+
+/** Exit with an error message. */
+#define FAIL(msg)						\
+	do {							\
+		fprintf(stderr, "%s: " msg "\n", __func__ );	\
+		goto CLEANUP;					\
+	} while (0)
+
+/** Exit with an error message and one argument. */
+#define FAIL1(msg, arg1)						\
+	do {								\
+		fprintf(stderr, "%s: " msg "\n", __func__ , arg1);	\
+		goto CLEANUP;						\
+	} while (0)
+
+#endif /* ENGINE_PKCS11_SRC_FAIL_H */

--- a/src/hw_pkcs11.c
+++ b/src/hw_pkcs11.c
@@ -157,24 +157,6 @@ static int pkcs11_engine_ctrl(ENGINE * e, int cmd, long i, void *p,
 	return 0;
 }
 
-#if 0
-/* set up default rsa_meth_st with overloaded rsa functions */
-/* the actual implementation needs to be in another object */
-
-static int (*orig_finish) (RSA * rsa);
-
-static int pkcs11_engine_rsa_finish(RSA * rsa)
-{
-
-	pkcs11_rsa_finish(rsa);
-
-	if (orig_finish)
-		orig_finish(rsa);
-	return 1;
-
-}
-#endif
-
 /* This internal function is used by ENGINE_pkcs11() and possibly by the
  * "dynamic" ENGINE support too */
 static int bind_helper(ENGINE * e)

--- a/src/hw_pkcs11.c
+++ b/src/hw_pkcs11.c
@@ -82,6 +82,7 @@
 #define CMD_QUIET		(ENGINE_CMD_BASE+4)
 #define CMD_LOAD_CERT_CTRL	(ENGINE_CMD_BASE+5)
 #define CMD_INIT_ARGS	(ENGINE_CMD_BASE+6)
+#define CMD_RELEASE_KEY	(ENGINE_CMD_BASE+7)
 
 static int pkcs11_engine_destroy(ENGINE * e);
 static int pkcs11_engine_ctrl(ENGINE * e, int cmd, long i, void *p,
@@ -120,6 +121,10 @@ static const ENGINE_CMD_DEFN pkcs11_cmd_defns[] = {
 	 "INIT_ARGS",
 	 "Specifies additional initialization arguments to the pkcs11 module",
 	 ENGINE_CMD_FLAG_STRING},
+	{CMD_RELEASE_KEY,
+	 "RELEASE_KEY",
+	 "Free given key and associated resources.",
+	 ENGINE_CMD_FLAG_INTERNAL},
 	{0, NULL, NULL, 0}
 };
 
@@ -144,6 +149,8 @@ static int pkcs11_engine_ctrl(ENGINE * e, int cmd, long i, void *p,
 		return load_cert_ctrl(e, p);
 	case CMD_INIT_ARGS:
 		return set_init_args((const char *)p);
+	case CMD_RELEASE_KEY:
+		return release_key((EVP_PKEY *)p);
 	default:
 		break;
 	}


### PR DESCRIPTION
This is my set of fixes that allow the user to stop the huge memory leaks that engine_pkcs11 currently suffers from.  (On x86_64, it's about 35KB per key.)

As mentioned in this thread:

http://sourceforge.net/mailarchive/message.php?msg_id=30821855

It's not the prettiest solution, but it's up and running and working fine on my embedded platform (Linux 3.4, OpenSSL 1.0.1e, PPC32) and it passes valgrind testing on x86_64 (Linux 3.8-3.9, OpenSSL 1.0.1e).  [Well, as much as *anything* using OpenSSL can pass valgrind...]

The critical commit is 91133b719c71; most of the others are prep or cleanup.

I don't see myself making any further changes to the code, so I'd like to see it integrated so others can use it, and so that it doesn't get lost in time.

Thanks,
Anthony Foiani