### PR TITLE
Wiki link updated

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,7 +1,7 @@
 This directory contains a snapshot of the engine_pkcs11 Wiki
 ============================================================
 
-The original wiki page is at http://www.opensc-project.org/engine_pkcs11/
+The original wiki page is at https://github.com/OpenSC/OpenSC/wiki/OpenSSL-engine-for-PKCS%2311-modules
 and includes a bug tracker and source browser.
 
 The wiki was transformed to html using the export-wiki shell


### PR DESCRIPTION
The link to the wiki in the docs directory was outdated, I have changed it to the current one (on github)
