### PR TITLE
PKCS#11 URI and system configuration fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,14 @@ AC_CHECK_HEADERS([ \
 	locale.h getopt.h dlfcn.h utmp.h \
 ])
 
+PKG_CHECK_MODULES(
+	[P11KIT],
+	[p11-kit-1],
+	[proxy_module="`$PKG_CONFIG --variable=proxy_module p11-kit-1`"
+	 AC_DEFINE_UNQUOTED([DEFAULT_PKCS11_MODULE], "${proxy_module}", [p11-kit proxy])],
+	[]
+)
+
 PKG_CHECK_MODULES([LIBP11], [libp11 >= 0.2.5],, [AC_MSG_ERROR([libp11 >= 0.2.5 is required])])
 
 PKG_CHECK_MODULES(

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -62,6 +62,7 @@ static char *init_args = NULL;
 
 int set_module(const char *modulename)
 {
+	free (module);
 	module = modulename ? strdup(modulename) : NULL;
 	return 1;
 }
@@ -169,13 +170,19 @@ int pkcs11_finish(ENGINE * engine)
 
 int pkcs11_init(ENGINE * engine)
 {
+	char *mod = module;
+
+#ifdef DEFAULT_PKCS11_MODULE
+	if (!mod)
+		mod = DEFAULT_PKCS11_MODULE;
+#endif
 	if (verbose) {
 		fprintf(stderr, "initializing engine\n");
 	}
 	ctx = PKCS11_CTX_new();
         PKCS11_CTX_init_args(ctx, init_args);
-	if (PKCS11_CTX_load(ctx, module) < 0) {
-		fprintf(stderr, "unable to load module %s\n", module);
+	if (PKCS11_CTX_load(ctx, mod) < 0) {
+		fprintf(stderr, "unable to load module %s\n", mod);
 		return 0;
 	}
 	return 1;

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -476,6 +476,14 @@ static int parse_pkcs11_uri(const char *uri, PKCS11_TOKEN **p_tok,
 		} else if (!strncmp(p, "id=", 3)) {
 			p += 3;
 			rv = parse_uri_attr(p, end - p, (void *)&id, id_len);
+		} else if (!strncmp(p, "type=", 5) || !strncmp(p, "object-type=", 12)) {
+                        p = strchr(p, '=') + 1;
+
+                        if ((end - p == 4 && !strncmp(p, "cert", 4)) ||
+                            (end - p == 7 && !strncmp(p, "private", 7))) {
+                                /* Actually, just ignore it */
+                        } else
+                                rv = 0;
 		} else {
 			rv = 0;
 		}

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -530,13 +530,11 @@ static X509 *pkcs11_load_cert(ENGINE * e, const char *s_slot_cert_id)
 		}
 		if (!n) {
 			fprintf(stderr,
-				"supported formats: <id>, <slot>:<id>, id_<id>, slot_<slot>-id_<id>, label_<label>, slot_<slot>-label_<label> or a PKCS#11 URI\n");
+				"The certificate ID should be a valid PKCS#11 URI as\n");
 			fprintf(stderr,
-				"where <slot> is the slot number as normal integer,\n");
+				"defined by RFC7512. The legacy ENGINE_pkcs11 ID format\n");
 			fprintf(stderr,
-				"and <id> is the id number as hex string.\n");
-			fprintf(stderr,
-				"and <label> is the textual key label string.\n");
+				"is also still accepted for now.\n");
 			return NULL;
 		}
 		if (verbose) {
@@ -718,13 +716,11 @@ static EVP_PKEY *pkcs11_load_key(ENGINE * e, const char *s_slot_key_id,
 
 		if (!n) {
 			fprintf(stderr,
-				"supported formats: <id>, <slot>:<id>, id_<id>, slot_<slot>-id_<id>, label_<label>, slot_<slot>-label_<label> or a PKCS#11 URI\n");
+				"The key ID should be a valid PKCS#11 URI as defined by\n");
 			fprintf(stderr,
-				"where <slot> is the slot number as normal integer,\n");
+				"RFC7512. The legacy ENGINE_pkcs11 ID format is also\n");
 			fprintf(stderr,
-				"and <id> is the id number as hex string.\n");
-			fprintf(stderr,
-				"and <label> is the textual key label string.\n");
+				"still accepted for now.\n");
 			return NULL;
 		}
 		if (verbose) {


### PR DESCRIPTION
These patches make engine_pkcs11 accept key/cert specifications in the form of a PKCS#11 URI as described at https://tools.ietf.org/html/draft-pechanec-pkcs11uri-16

There is also a patch to make it automatically load p11-kit-proxy.so as its PKCS#11 provider instead of just failing if none is specified. This has the effect of making it Just Work™ with the system configuration for which modules should be present.

These are both important standardisation efforts to make PKCS#11 more usable on the desktop. We really need provider modules to be able to automatically install themselves with the system, and a consistent way of specifying objects within PKCS#11 tokens. Which is what we get from p11-kit, and the PKCS#11 URI, respectively.

Note that the first patch doesn't add a dependency on p11-kit libraries; it *only* uses pkg-config to determine the location of the p11-kit-proxy.so provider module — which loads all the providers which are registered in the system configuration, into slots of itself.