### PR TITLE
Add init_flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ PKG_CHECK_MODULES(
 	[]
 )
 
-PKG_CHECK_MODULES([LIBP11], [libp11 >= 0.2.5],, [AC_MSG_ERROR([libp11 >= 0.2.5 is required])])
+PKG_CHECK_MODULES([LIBP11], [libp11 >= 0.2.9],, [AC_MSG_ERROR([libp11 >= 0.2.9 is required])])
 
 PKG_CHECK_MODULES(
 	[OPENSSL],

--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -59,6 +59,7 @@ static int verbose = 0;
 static char *module = NULL;
 
 static char *init_args = NULL;
+static int init_flags = 0;
 
 int set_module(const char *modulename)
 {
@@ -152,6 +153,12 @@ int set_init_args(const char *init_args_orig)
 	return 1;
 }
 
+int set_init_flags(int flags)
+{
+	init_flags = flags;
+	return 1;
+}
+
 int pkcs11_finish(ENGINE * engine)
 {
 	if (ctx) {
@@ -180,7 +187,8 @@ int pkcs11_init(ENGINE * engine)
 		fprintf(stderr, "initializing engine\n");
 	}
 	ctx = PKCS11_CTX_new();
-        PKCS11_CTX_init_args(ctx, init_args);
+	PKCS11_CTX_init_args(ctx, init_args);
+	PKCS11_CTX_init_flags(ctx, init_flags);
 	if (PKCS11_CTX_load(ctx, mod) < 0) {
 		fprintf(stderr, "unable to load module %s\n", mod);
 		return 0;

--- a/src/engine_pkcs11.h
+++ b/src/engine_pkcs11.h
@@ -38,6 +38,7 @@ int set_module(const char *modulename);
 int set_pin(const char *pin);
 
 int set_init_args(const char *init_args_orig);
+int set_init_flags(int);
 
 int load_cert_ctrl(ENGINE * e, void *p);
 

--- a/src/hw_pkcs11.c
+++ b/src/hw_pkcs11.c
@@ -84,6 +84,7 @@
 #define CMD_QUIET		(ENGINE_CMD_BASE+4)
 #define CMD_LOAD_CERT_CTRL	(ENGINE_CMD_BASE+5)
 #define CMD_INIT_ARGS	(ENGINE_CMD_BASE+6)
+#define CMD_INIT_FLAGS	(ENGINE_CMD_BASE+7)
 
 static int pkcs11_engine_destroy(ENGINE * e);
 static int pkcs11_engine_ctrl(ENGINE * e, int cmd, long i, void *p,
@@ -122,6 +123,11 @@ static const ENGINE_CMD_DEFN pkcs11_cmd_defns[] = {
 	 "INIT_ARGS",
 	 "Specifies additional initialization arguments to the pkcs11 module",
 	 ENGINE_CMD_FLAG_STRING},
+	{CMD_INIT_FLAGS,
+	 "INIT_FLAGS",
+	 "Specifies additional initialization flags to the pkcs11 module, " \
+	 "use '2' for CKF_OS_LOCKING_OK.",
+	 ENGINE_CMD_FLAG_NUMERIC},
 	{0, NULL, NULL, 0}
 };
 
@@ -153,6 +159,8 @@ static int pkcs11_engine_ctrl(ENGINE * e, int cmd, long i, void *p,
 		return load_cert_ctrl(e, p);
 	case CMD_INIT_ARGS:
 		return set_init_args((const char *)p);
+	case CMD_INIT_FLAGS:
+		return set_init_flags((int)i);
 	default:
 		break;
 	}


### PR DESCRIPTION
Add interface to PKCS11_CTX_init_flags() in order to set CKF_OS_LOCKING_OK flag
for NSS softoken.

The PR depends on https://github.com/OpenSC/libp11/pull/19