### PR TITLE
Exercise different methods for setting the PIN

### DIFF
--- a/tests/evp-sign.c
+++ b/tests/evp-sign.c
@@ -40,6 +40,86 @@
 #include <openssl/engine.h>
 #include <openssl/conf.h>
 
+/* UI method that's only used to fail if get_pin inside engine_pkcs11
+   has failed to pick up in a PIN sent in with ENGINE_ctrl_cmd_string */
+static UI_METHOD *ui_detect_failed_ctrl = NULL;
+
+static int ui_open_fail(UI *ui)
+{
+	fprintf(stderr, "It seems like get_pin fell through even though the pin should already be set!\n");
+	return 0;
+}
+
+/* method that's to be used for prompting with a default (which is an
+   alternative to sending in a PIN sent in with ENGINE_ctrl_cmd_string) */
+static UI_METHOD *ui_console_with_default = NULL;
+
+static int ui_read(UI *ui, UI_STRING *uis)
+{
+	if (UI_get_input_flags(uis) & UI_INPUT_FLAG_DEFAULT_PWD
+	    && UI_get0_user_data(ui)) {
+		switch (UI_get_string_type(uis)) {
+		case UIT_PROMPT:
+		case UIT_VERIFY:
+		{
+			/* If there is a default PIN, use it
+			   instead of reading from the console */
+			const char *password =
+				((const char *)UI_get0_user_data(ui));
+			if (password && password[0] != '\0') {
+				UI_set_result(ui, uis, password);
+				return 1;
+			}
+		}
+		default:
+			break;
+		}
+	}
+	return UI_method_get_reader(UI_OpenSSL())(ui, uis);
+}
+
+static int ui_write(UI *ui, UI_STRING *uis)
+{
+	if (UI_get_input_flags(uis) & UI_INPUT_FLAG_DEFAULT_PWD
+	    && UI_get0_user_data(ui)) {
+		switch (UI_get_string_type(uis)) {
+		case UIT_PROMPT:
+		case UIT_VERIFY:
+		{
+			/* If there is a default PIN, just
+			   return without outputing any prompt */
+			const char *password =
+				((const char *)UI_get0_user_data(ui));
+			if (password && password[0] != '\0')
+				return 1;
+		}
+		default:
+			break;
+		}
+	}
+	return UI_method_get_writer(UI_OpenSSL())(ui, uis);
+}
+
+static void setup_ui()
+{
+	UI_METHOD *default_method = UI_OpenSSL();
+
+	ui_detect_failed_ctrl = UI_create_method("Fail if used");
+	UI_method_set_opener(ui_detect_failed_ctrl, ui_open_fail);
+	/* No other functions need setting, as the UI will never use them */
+
+	ui_console_with_default = UI_create_method("Reader with possible default");
+	UI_method_set_opener(ui_console_with_default,
+			     UI_method_get_opener(default_method));
+	UI_method_set_reader(ui_console_with_default, ui_read);
+	UI_method_set_writer(ui_console_with_default, ui_write);
+	UI_method_set_flusher(ui_console_with_default,
+			      UI_method_get_flusher(default_method));
+	UI_method_set_closer(ui_console_with_default,
+			     UI_method_get_closer(default_method));
+}
+
+
 static void display_openssl_errors(int l)
 {
 	const char *file;
@@ -73,16 +153,31 @@ int main(int argc, char **argv)
 	EVP_MD_CTX ctx;
 	const char *module_path, *efile;
 	BIO *in, *b;
+	enum { NONE, BY_DEFAULT, BY_CTRL } pin_method = NONE;
+	UI_METHOD *ui_method = NULL;
+	void *ui_extra = NULL;
 
 	if (argc < 5) {
-		fprintf(stderr, "usage: %s [PIN] [CONF] [private key URL] [module]\n", argv[0]);
+		fprintf(stderr, "usage: %s [PIN setting method] [PIN] [CONF] [private key URL] [module]\n", argv[0]);
+		fprintf(stderr, "\n");
+		fprintf(stderr, "PIN setting method can be 'default' or 'ctrl'\n");
 		exit(1);
 	}
 
-	key_pass = argv[1];
-	private_key_name = argv[3];
-	module_path = argv[4];
-	efile = argv[2];
+	if (strcmp(argv[1], "default") == 0)
+		pin_method = BY_DEFAULT;
+	else if (strcmp(argv[1], "ctrl") == 0)
+		pin_method = BY_CTRL;
+	else {
+		fprintf(stderr, "First argument MUST be 'default' or 'ctrl'\n");
+		exit(1);
+	}
+	key_pass = argv[2];
+	private_key_name = argv[4];
+	module_path = argv[5];
+	efile = argv[3];
+
+	setup_ui();
 
 	ret = CONF_modules_load_file(efile, "engines", 0);
 	if (ret <= 0) {
@@ -113,12 +208,22 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	if (key_pass && !ENGINE_ctrl_cmd_string(e, "PIN", key_pass, 0)) {
-		display_openssl_errors(__LINE__);
-		exit(1);
+	switch (pin_method) {
+	case BY_DEFAULT:
+		ui_method = ui_console_with_default;
+		ui_extra = key_pass;
+		break;
+	case BY_CTRL:
+		ui_method = ui_detect_failed_ctrl;
+		ui_extra = NULL;
+		if (key_pass && !ENGINE_ctrl_cmd_string(e, "PIN", key_pass, 0)) {
+			display_openssl_errors(__LINE__);
+			exit(1);
+		}
 	}
 
-	private_key = ENGINE_load_private_key(e, private_key_name, NULL, NULL);
+	private_key = ENGINE_load_private_key(e, private_key_name,
+					      ui_method, ui_extra);
 	if (!private_key) {
 		fprintf(stderr, "cannot load: %s\n", private_key_name);
 		display_openssl_errors(__LINE__);

--- a/tests/softhsm
+++ b/tests/softhsm
@@ -27,25 +27,37 @@ sed -e "s|@MODULE_PATH@|${ADDITIONAL_PARAM}|g" -e "s|@ENGINE_PATH@|../src/.libs/
 
 export OPENSSL_ENGINES="../src/.libs/"
 
-./evp-sign false engines.cnf "pkcs11:token=libp11-test;id=%00%01%02%03;object=server-key;type=private;pin-value=1234" ${ADDITIONAL_PARAM}
+./evp-sign ctrl false engines.cnf "pkcs11:token=libp11-test;id=%00%01%02%03;object=server-key;type=private;pin-value=1234" ${ADDITIONAL_PARAM}
 if test $? != 0;then
-	echo "Basic PKCS #11 test failed"
+	echo "Basic PKCS #11 test, using ctrl failed"
 	exit 1;
 fi
 
-./evp-sign 1234 engines.cnf "pkcs11:token=libp11-test;id=%00%01%02%03;object=server-key;type=private" ${ADDITIONAL_PARAM}
+./evp-sign default false engines.cnf "pkcs11:token=libp11-test;id=%00%01%02%03;object=server-key;type=private;pin-value=1234" ${ADDITIONAL_PARAM}
 if test $? != 0;then
-	echo "Basic PKCS #11 test without pin-value failed"
+	echo "Basic PKCS #11 test, using default failed"
 	exit 1;
 fi
 
-./evp-sign 1234 engines.cnf "label_server-key" ${ADDITIONAL_PARAM}
+./evp-sign ctrl 1234 engines.cnf "pkcs11:token=libp11-test;id=%00%01%02%03;object=server-key;type=private" ${ADDITIONAL_PARAM}
+if test $? != 0;then
+	echo "Basic PKCS #11 test without pin-value, using ctrl failed"
+	exit 1;
+fi
+
+./evp-sign default 1234 engines.cnf "pkcs11:token=libp11-test;id=%00%01%02%03;object=server-key;type=private" ${ADDITIONAL_PARAM}
+if test $? != 0;then
+	echo "Basic PKCS #11 test without pin-value, using default failed"
+	exit 1;
+fi
+
+./evp-sign ctrl 1234 engines.cnf "label_server-key" ${ADDITIONAL_PARAM}
 if test $? != 0;then
 	echo "Basic PKCS #11 test with legacy name #1 failed"
 	exit 1;
 fi
 
-./evp-sign 1234 engines.cnf "id_00010203" ${ADDITIONAL_PARAM}
+./evp-sign default 1234 engines.cnf "id_00010203" ${ADDITIONAL_PARAM}
 if test $? != 0;then
 	echo "Basic PKCS #11 test with legacy name #2 failed"
 	exit 1;


### PR DESCRIPTION
tests/evp-sign.c is enhanced with a couple of UI_METHODs to exercise
having the PIN set through callback data to a UI_METHOD called by
get_pin, or set through ENGINE_ctrl_cmd_string.  In the latter case,
there is still a UI_METHOD used, but that one will fail on use,
because that will mean get_pin was called and didn't pick up the
existing pin.

tests/softhsm gets some additional runs of evp-sign to make sure it
works in both pin setting modes.