### PR TITLE
* Prevent potential memory leak when calling set_init_args.

### DIFF
--- a/src/engine_pkcs11.c
+++ b/src/engine_pkcs11.c
@@ -158,6 +158,7 @@ static int get_pin(UI_METHOD * ui_method, void *callback_data)
 
 int set_init_args(const char *init_args_orig)
 {
+	free(init_args);
 	init_args = init_args_orig ? strdup(init_args_orig) : NULL;
 	return 1;
 }


### PR DESCRIPTION
these four functions in src/engine_pkcs11.c to set static global data (set_module,
set_pin, get_pin and set_init_args) used not to free memories pointed by the
corresponding pointers before assigning them to newly allocated memories, which
may cause memory leaks if they are called more than once.
Now, the bugs related to set_module, set_pin and get_pin are fixed here, but
the one of set_init_args is not, I believe this may cause problem if left as now it is.
